### PR TITLE
feat: support usernames through synthetic emails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@ HOSTNAME=localhost
 SECRET_KEY=some-secret-key
 PROJECT_ID=gcp-project-id
 PROVIDER_ID=auth-provider-id
+USERNAME_EMAIL_DOMAIN=scim.example.com

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,4 +8,5 @@ export class Config {
   readonly secretKey = Buffer.from(getenv("SECRET_KEY"), "utf-8")
   readonly projectId = getenv("PROJECT_ID")
   readonly providerId = getenv("PROVIDER_ID")
+  readonly usernameEmailDomain = getenv("USERNAME_EMAIL_DOMAIN")
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -69,6 +69,32 @@ export class PatchError extends DomainError<"patch", unknown> {
   }
 }
 
+export class InvalidSyntaxError extends DomainError<"invalidSyntax", unknown> {
+  type = "invalidSyntax" as const
+  statusCode = 400
+
+  constructor(err: Error) {
+    super({
+      message: "Validation failed",
+      scimType: "invalidSyntax",
+      metadata:
+        err instanceof ZodError
+          ? err.errors
+          : // TODO: don't return internal error details to clients
+            {
+              message: err.message,
+              stack: err.stack,
+              cause: err.cause &&
+                err.cause instanceof Error && {
+                  message: err.cause.message,
+                  stack: err.cause.stack,
+                },
+            },
+      cause: err,
+    })
+  }
+}
+
 export class ValidationError extends DomainError<"validation", unknown> {
   type = "validation" as const
   statusCode = 400

--- a/src/idp-adapters/types.ts
+++ b/src/idp-adapters/types.ts
@@ -9,6 +9,7 @@ import type {
 
 export type CreateUser = {
   externalId: string | undefined
+  userName: string
   email: string
   displayName: string
   disabled: boolean

--- a/src/middleware/error.middleware.ts
+++ b/src/middleware/error.middleware.ts
@@ -3,9 +3,10 @@ import type {Context, Middleware, Next} from "koa"
 import {
   DomainError,
   InternalServerError,
+  InvalidSyntaxError,
   NotFoundError,
-  ValidationError,
 } from "../errors"
+
 export function errorMiddleware(): Middleware {
   return async function errorMiddleware(ctx: Context, next: Next) {
     try {
@@ -28,7 +29,7 @@ export function errorMiddleware(): Middleware {
         KoaRuntimeError.isKoaError(err) &&
         err.phase === "request_validation"
       ) {
-        return doErrorResponse(ctx, new ValidationError(cause))
+        return doErrorResponse(ctx, new InvalidSyntaxError(cause))
       }
 
       if (cause instanceof DomainError) {

--- a/src/routes/groups.ts
+++ b/src/routes/groups.ts
@@ -86,7 +86,7 @@ export class GroupsHandlers implements Implementation {
       itemsPerPage: groups.length,
       schemas: ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
       Resources: groups,
-      startIndex: 0,
+      startIndex: query.startIndex,
       totalResults: groups.length,
     })
   }

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -34,11 +34,12 @@ const requestBodyToCreateUser = (
     )
   }
 
-  const externalId = body.externalId || body.userName
+  const externalId = body.externalId
 
   const displayName = body.displayName || body.name?.formatted || "Unknown"
 
   return {
+    userName: body.userName,
     email: primaryEmail.value,
     externalId,
     displayName,
@@ -73,7 +74,7 @@ export class UsersHandlers implements Implementation {
       itemsPerPage: users.length,
       schemas: ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
       Resources: users,
-      startIndex: 0,
+      startIndex: query.startIndex,
       totalResults: users.length,
     })
   }
@@ -109,7 +110,7 @@ export class UsersHandlers implements Implementation {
 
     await this.idpAdapter.updateUser(user.id, requestBodyToCreateUser(updated))
 
-    return respond.with200().body(user)
+    return respond.with200().body(updated)
   }
 
   deleteScimV2UsersId: DeleteScimV2UsersId = async ({params}, respond) => {

--- a/src/scim-schemas.ts
+++ b/src/scim-schemas.ts
@@ -815,7 +815,7 @@ export const ScimSchemaCoreGroup = {
       type: "string",
       multiValued: false,
       description: "A human-readable name for the Group. REQUIRED.",
-      required: false,
+      required: true,
       caseExact: false,
       mutability: "readWrite",
       returned: "default",


### PR DESCRIPTION
firebase uses an email as the username, but scim doesn't have this restriction.

we can workaround this by "synthesizing" a valid email from the username, and then just being careful to perform this during login (which tbf will be annoying as it'll have to happen client-side)

this is achieved by base36 encoding the userName and using this in front of a staticly configured domain.

I haven't fully thought through if this is a good idea or not yet - eg: I'm not sure how this will play out for OIDC / SAML

also includes a few misc fixes from testing with the Entra validator and others.